### PR TITLE
Fixes issue #109 from Wi-Fi Buddy 

### DIFF
--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -23,7 +23,8 @@
         android:id="@+id/noPromptServiceRegistrationSwitch"
         android:text="@string/action_register_no_prompt"
         android:checked="false"
-        android:enabled="false" />
+        android:enabled="false"
+        android:visibility="invisible" />
 
     <Button
         style="@style/styleButtonDefault"


### PR DESCRIPTION
Fixes issue [109](https://github.com/Crash-Test-Buddies/WiFi-Buddy/issues/109) from Wi-Fi Buddy -  Chat opens when no-prompt service is registered

Hid the no-prompt registration switch for now since we're not really using it. 
