### PR TITLE
Lets wifi buddy set up service discovery

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ dependencies {
     compile 'com.android.support:design:23.4.0'
     compile 'io.nlopez.smartlocation:library:3.2.1'
     compile 'com.google.android.gms:play-services-appindexing:9.0.1'
-    compile 'com.github.Crash-Test-Buddies:WiFi-Buddy:v0.3.2'
+    compile 'com.github.Crash-Test-Buddies:WiFi-Buddy:v0.3.4'
 }


### PR DESCRIPTION
Lets wifi buddy set up service discovery. Prevents listeners from being registered more than once and prevents service discovery requests from being added more than once. Also some other refactoring. 
